### PR TITLE
EntryKitの導入

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: required
 
 language: ruby
+cache: bundler
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
   # Installs Nginx
   apk add --update \
     nginx && \
-  mkdir /var/run/nginx/ &&
+  mkdir /var/run/nginx/ && \
   mkdir /var/www/html/ && \
   # Installs PHP
   apk add --update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,16 @@ FROM alpine:3.4
 MAINTAINER Ryuichi Komeda <komeda@hivelocity.co.jp>
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-
   # Installs Supervisor
   apk add --update \
     supervisor && \
   mkdir /var/run/supervisor/ && \
   rm -rf /etc/supervisord.conf && \
-
   # Installs Nginx
   apk add --update \
     nginx && \
-  mkdir /var/run/nginx/ && \
-
+  mkdir /var/run/nginx/ &&
+  mkdir /var/www/html/ && \
   # Installs PHP
   apk add --update \
     php5 \
@@ -29,11 +27,10 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
     php5-imagick \
     php5-memcache \
     php5-redis && \
-
   # Clean up cache
   rm -rf /var/cache/apk/*
 
-ADD files /
+COPY files /
 
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
## 概要
EntryKitを導入し、conf周りのファイルの設置とプロセスの起動を設定する。
そのため、Supervisorは用無しなので削除します。
http://qiita.com/spesnova/items/bae6406bf69d2dc6f88b

## 変更点
- [ ] EntryKitバイナリ設置処理の追加
- [ ] Supervisor削除
- [ ] ENTRYPOINTをEntryKitのcodepに置き換え
- [ ] Nginx設定ファイルのテンプレート化
- [ ] PHP設定ファイルのテンプレート化