### PR TITLE
.dockerignoreファイルの追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+vendor/bundle


### PR DESCRIPTION
不要なファイルを指定することによってビルド時間が短縮されるので、追加した。