### PR TITLE
SQLインポート機能を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV ENTRYKIT_VERSION=0.4.0 \
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
   # Installs EntryKit
-  apk add --update openssl && \
+  apk add --update openssl bash && \
   wget https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz && \
   tar -xvzf entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz && \
   rm entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz && \

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -9,22 +9,22 @@ if [ ! -d "/var/lib/mysql/mysql" ]; then
     mysql_install_db --datadir="/var/lib/mysql" --rpm
 
     /usr/bin/mysqld --user=root --skip-networking &
-		pid="$!"
+    pid="$!"
 
     mysql=( mysql --protocol=socket -uroot )
 
     for i in {30..0}; do
-			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
-				break
-			fi
-			echo 'MySQL init process in progress...'
-			sleep 1
-		done
+      if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
+        break
+      fi
+      echo 'MySQL init process in progress...'
+      sleep 1
+    done
 
-		if [ "$i" = 0 ]; then
-			echo >&2 'MySQL init process failed.'
-			exit 1
-		fi
+    if [ "$i" = 0 ]; then
+      echo >&2 'MySQL init process failed.'
+      exit 1
+    fi
 
     "${mysql[@]}" <<-EOSQL
       UPDATE mysql.user SET Password=PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User='root' ;
@@ -41,7 +41,7 @@ EOSQL
     echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
     echo "Created MySQL Database: $MYSQL_DATABASE"
     echo
-		mysql+=( "$MYSQL_DATABASE" )
+    mysql+=( "$MYSQL_DATABASE" )
 
     "${mysql[@]}" <<-EOSQL
       CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}' ;
@@ -67,10 +67,10 @@ EOSQL
       done
     fi
 
-    if ! kill -s TERM "$pid" || ! wait "$pid"; then
-			echo >&2 'MySQL init process failed.'
-			exit 1
-		fi
+  if ! kill -s TERM "$pid" || ! wait "$pid"; then
+    echo >&2 'MySQL init process failed.'
+    exit 1
+  fi
 fi
 
 exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf

--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -1,29 +1,76 @@
-#!/bin/sh
+#!/bin/bash
 
-set -e
+set -eo pipefail
 
+# Initializing mysql and create an user,database
 if [ ! -d "/var/lib/mysql/mysql" ]; then
     mkdir -p /var/lib/mysql
 
-    mysql_install_db --user=mysql --datadir="/var/lib/mysql" --rpm
+    mysql_install_db --datadir="/var/lib/mysql" --rpm
 
-    tempfile=`mktemp`
-    if [ ! -f "$tempfile" ]; then
-        return 1
+    /usr/bin/mysqld --user=root --skip-networking &
+		pid="$!"
+
+    mysql=( mysql --protocol=socket -uroot )
+
+    for i in {30..0}; do
+			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
+				break
+			fi
+			echo 'MySQL init process in progress...'
+			sleep 1
+		done
+
+		if [ "$i" = 0 ]; then
+			echo >&2 'MySQL init process failed.'
+			exit 1
+		fi
+
+    "${mysql[@]}" <<-EOSQL
+      UPDATE mysql.user SET Password=PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User='root' ;
+      DELETE FROM mysql.user WHERE User='' ;
+      DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1') ;
+      DROP DATABASE IF EXISTS test ;
+      FLUSH PRIVILEGES ;
+EOSQL
+    echo "Finished mysql_secure_install"
+    echo
+
+    mysql+=( -p"${MYSQL_ROOT_PASSWORD}" )
+
+    echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
+    echo "Created MySQL Database: $MYSQL_DATABASE"
+    echo
+		mysql+=( "$MYSQL_DATABASE" )
+
+    "${mysql[@]}" <<-EOSQL
+      CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}' ;
+      GRANT ALL ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%' ;
+      FLUSH PRIVILEGES ;
+EOSQL
+    echo "Created MySQL User: $MYSQL_USER"
+    echo
+
+    if [ -d "/initdb.d/schema" ]; then
+      for f in /initdb.d/schema/*; do
+        case "$f" in
+          *.sql) "${mysql[@]}" < "$f"; echo "Imported Schema: $f"; echo ;;
+        esac
+      done
     fi
 
-    cat << EOF > $tempfile
-  UPDATE mysql.user SET Password=PASSWORD('${MYSQL_ROOT_PASSWORD}') WHERE User='root';
-  DELETE FROM mysql.user WHERE User='';
-  DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');
-  DROP DATABASE IF EXISTS test;
-  FLUSH PRIVILEGES;
-  CREATE DATABASE IF NOT EXISTS ${MYSQL_DATABASE} CHARACTER SET utf8 COLLATE utf8_general_ci;
-  GRANT ALL ON ${MYSQL_DATABASE}.* to '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
-EOF
+    if [ -d "/initdb.d/seeds" ]; then
+      for f in /initdb.d/seeds/*; do
+        case "$f" in
+          *.sql) "${mysql[@]}" < "$f"; echo "Imported Seeds: $f"; echo ;;
+        esac
+      done
+    fi
 
-    /usr/bin/mysqld --user=root --bootstrap --verbose=0 < $tempfile
-    rm -rf $tempfile
+    if ! kill -s TERM "$pid" || ! wait "$pid"; then
+			echo >&2 'MySQL init process failed.'
+			exit 1
+		fi
 fi
 
 exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf


### PR DESCRIPTION
あわせて、セキュアインストール処理も修正。

[Docker公式のスクリプト](https://github.com/docker-library/mariadb/blob/master/10.1/docker-entrypoint.sh)をだいぶ参考（拝借）させてもらっている。

## 最終的な処理の流れ (entrypoint.shの中身)

1. mysqld起動
1. mysqldが起動するまで待機
1. セキュアインストールに該当するSQLを実行
1. データベースを作成
1. ユーザーを作成
1. インポートしたいスキーマのSQLを実行
1. インポートしたい初期データのSQLを実行
1. Supervisord起動