### PR TITLE
ミドルウェア設定の調整

### DIFF
--- a/files/entrypoint.sh
+++ b/files/entrypoint.sh
@@ -73,4 +73,7 @@ EOSQL
   fi
 fi
 
+# Change owner/group in document root directory
+chown -R nginx:nginx $NGINX_DOCUMENT_ROOT
+
 exec /usr/bin/supervisord -c /etc/supervisor/supervisord.conf

--- a/files/etc/mysql/my.cnf.tmpl
+++ b/files/etc/mysql/my.cnf.tmpl
@@ -116,18 +116,18 @@ server-id      	= 1
 #log-bin=mysql-bin
 
 # Uncomment the following if you are using InnoDB tables
-#innodb_data_home_dir = /var/lib/mysql
-#innodb_data_file_path = ibdata1:10M:autoextend
-#innodb_log_group_home_dir = /var/lib/mysql
+innodb_data_home_dir = /var/lib/mysql
+innodb_data_file_path = ibdata1:10M:autoextend
+innodb_log_group_home_dir = /var/lib/mysql
 # You can set .._buffer_pool_size up to 50 - 80 %
 # of RAM but beware of setting memory usage too high
-#innodb_buffer_pool_size = 16M
-#innodb_additional_mem_pool_size = 2M
+innodb_buffer_pool_size = 1024MB
+innodb_additional_mem_pool_size = 2M
 # Set .._log_file_size to 25 % of buffer pool size
-#innodb_log_file_size = 5M
-#innodb_log_buffer_size = 8M
-#innodb_flush_log_at_trx_commit = 1
-#innodb_lock_wait_timeout = 50
+innodb_log_file_size = 5M
+innodb_log_buffer_size = 8M
+innodb_flush_log_at_trx_commit = 1
+innodb_lock_wait_timeout = 50
 
 [mysqldump]
 quick

--- a/files/etc/php5/php.ini.tmpl
+++ b/files/etc/php5/php.ini.tmpl
@@ -390,7 +390,7 @@ max_input_time = 60
 
 ; Maximum amount of memory a script may consume (128MB)
 ; http://php.net/memory-limit
-memory_limit = 128M
+memory_limit = 512M
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Error handling and logging ;
@@ -657,7 +657,7 @@ auto_globals_jit = On
 ; Its value may be 0 to disable the limit. It is ignored if POST data reading
 ; is disabled through enable_post_data_reading.
 ; http://php.net/post-max-size
-post_max_size = 8M
+post_max_size = 64M
 
 ; Automatically add files before PHP document.
 ; http://php.net/auto-prepend-file
@@ -810,7 +810,7 @@ file_uploads = On
 
 ; Maximum allowed size for uploaded files.
 ; http://php.net/upload-max-filesize
-upload_max_filesize = 2M
+upload_max_filesize = 64M
 
 ; Maximum number of files that can be uploaded via a single request
 max_file_uploads = 20
@@ -1007,7 +1007,7 @@ pdo_mysql.default_socket=
 
 [Phar]
 ; http://php.net/phar.readonly
-;phar.readonly = On
+phar.readonly = Off
 
 ; http://php.net/phar.require-hash
 ;phar.require_hash = On
@@ -1384,7 +1384,7 @@ bcmath.scale = 0
 [Session]
 ; Handler used to store/retrieve data.
 ; http://php.net/session.save-handler
-session.save_handler = files
+session.save_handler = redis
 
 ; Argument passed to save_handler.  In the case of files, this is the path
 ; where data files are stored. Note: Windows users have to change this
@@ -1413,7 +1413,7 @@ session.save_handler = files
 ; where MODE is the octal representation of the mode. Note that this
 ; does not overwrite the process's umask.
 ; http://php.net/session.save-path
-;session.save_path = "/tmp"
+session.save_path = "tcp://127.0.0.1:6379"
 
 ; Whether to use strict session mode.
 ; Strict session mode does not accept uninitialized session ID and regenerate
@@ -1873,10 +1873,10 @@ ldap.max_links = -1
 
 [opcache]
 ; Determines if Zend OPCache is enabled
-;opcache.enable=0
+opcache.enable=1
 
 ; Determines if Zend OPCache is enabled for the CLI version of PHP
-;opcache.enable_cli=0
+opcache.enable_cli=1
 
 ; The OPcache shared memory storage size.
 ;opcache.memory_consumption=64


### PR DESCRIPTION
PHP、MySQLの設定を調整。
また、ドキュメントルート・ディレクトリのオーナーとグループを `nginx:nginx`に変更。