### PR TITLE
NginxのSSL証明書を設置

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,15 @@ RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/reposit
   apk add --update \
     nginx && \
   mkdir /var/run/nginx/ && \
+  mkdir /etc/nginx/ssl/ && \
+  openssl genrsa -out /etc/nginx/ssl/server.key 2048 2>&1 && \
+  openssl req -new -batch \
+    -key /etc/nginx/ssl/server.key \
+    -out /etc/nginx/ssl/server.csr && \
+  openssl x509 -req -days 365 \
+    -in /etc/nginx/ssl/server.csr \
+    -signkey /etc/nginx/ssl/server.key \
+    -out /etc/nginx/ssl/server.crt 2>&1 && \
   # Installs PHP
   apk add --update \
     php5 \
@@ -77,11 +86,17 @@ EXPOSE 80 443 3306
 ENTRYPOINT [ \
   "render", \
     "/etc/nginx/nginx.conf", \
-    "/etc/nginx/conf.d/default.conf", \
+    "/etc/nginx/conf.d/default.conf", "--", \
+  "render", \
+    "/etc/nginx/conf.d/default.ssl.conf", "--", \
+  "render", \
     "/etc/php5/php.ini", \
-    "/etc/php5/php-fpm.conf", \
-    "/etc/mysql/my.cnf", \
-    "/etc/redis/redis.conf", \
+    "/etc/php5/php-fpm.conf", "--", \
+  "render", \
+    "/etc/mysql/my.cnf", "--", \
+  "render", \
+    "/etc/redis/redis.conf", "--", \
+  "render", \
     "/etc/supervisor/supervisord.conf", "--", \
   "/entrypoint.sh" \
 ]

--- a/files/etc/nginx/conf.d/default.ssl.conf.tmpl
+++ b/files/etc/nginx/conf.d/default.ssl.conf.tmpl
@@ -1,0 +1,38 @@
+server {
+    listen       443;
+    server_name  {{ var "NGINX_SERVER_NAME" }};
+
+    set $root_path '{{ var "NGINX_DOCUMENT_ROOT" }}';
+
+    ssl                 on;
+		ssl_certificate     /etc/nginx/ssl/server.crt;
+		ssl_certificate_key /etc/nginx/ssl/server.key;
+
+    error_log /var/log/nginx/{{ var "NGINX_SERVER_NAME" }}.ssl.error.log warn;
+    access_log /var/log/nginx/{{ var "NGINX_SERVER_NAME" }}.ssl.access.log main;
+
+    location / {
+        root      $root_path;
+        index     index.html index.php;
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~*\.php$ {
+        fastcgi_pass            127.0.0.1:9000;
+        fastcgi_index           index.php;
+        include                 fastcgi_params;
+        fastcgi_param           SCRIPT_FILENAME $root_path$fastcgi_script_name;
+        fastcgi_param           DOCUMENT_ROOT $root_path;
+        fastcgi_param           HTTPS on;
+        fastcgi_buffers         8 128k;
+        fastcgi_buffer_size     8k;
+        fastcgi_read_timeout    100;
+        fastcgi_connect_timeout 60;
+        fastcgi_send_timeout    90;
+        fastcgi_store           off;
+    }
+
+    location ~ /\.ht {
+        deny  all;
+    }
+}

--- a/script/docker.sh
+++ b/script/docker.sh
@@ -33,6 +33,7 @@ run() {
     --name ${CONTAINER_NAME} \
     -u root \
     -p 80:80 \
+    -p 443:443 \
     -p 3306:3306 \
     ${IMAGE_NAME}:latest
 

--- a/spec/mantle/nginx_spec.rb
+++ b/spec/mantle/nginx_spec.rb
@@ -17,6 +17,18 @@ describe file('/etc/nginx/conf.d/default.conf') do
   it { should be_file }
 end
 
+describe file('/etc/nginx/conf.d/default.ssl.conf') do
+  it { should be_file }
+end
+
+describe file('/etc/nginx/ssl/server.crt') do
+  it { should be_file }
+end
+
+describe file('/etc/nginx/ssl/server.key') do
+  it { should be_file }
+end
+
 describe command('nginx -t') do
   its(:exit_status) { should eq 0 }
 end
@@ -26,5 +38,9 @@ describe process("nginx") do
 end
 
 describe port(80) do
+  it { should be_listening }
+end
+
+describe port(443) do
   it { should be_listening }
 end


### PR DESCRIPTION
## やったこと
- 証明書作成フローをDockerfileに追加
- SSL用のNginx設定ファイルを追加
- Entrypointのコマンドを調整
    - レンダリングされない現象が発生したので、ミドルごとにrenderコマンドを分けた。（今後原因をしらべる必要あり）

## 追加したテスト
- `spec/mantle/nginx_spec.rb`
  - 証明書ファイルがあるか
  - 443ポートがつかえるか