### PR TITLE
PHPのセッションハンドラをredisに変更

### DIFF
--- a/files/etc/php7/php.ini.tmpl
+++ b/files/etc/php7/php.ini.tmpl
@@ -1308,7 +1308,7 @@ bcmath.scale = 0
 [Session]
 ; Handler used to store/retrieve data.
 ; http://php.net/session.save-handler
-session.save_handler = files
+session.save_handler = redis
 
 ; Argument passed to save_handler.  In the case of files, this is the path
 ; where data files are stored. Note: Windows users have to change this


### PR DESCRIPTION
phpのセッションハンドラが `files`でパスが `redis`になっていたため、`tcp://127.0.0.1:6379/php_sess/` とかにファイルを開けようとしてエラーになっていた。

```ini
session.save_handler = files
session.save_path = tcp://127.0.0.1:6379
```

弊社標準環境はredisなので、セッションハンドラをredisに変更しますたん。
mantleをcontributeする練習も兼ねてます( ತಎತ)